### PR TITLE
Ajout des taux 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Extraits de
 - [Arrêté du 30 décembre 2025](https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000053228984)
 - [Arrêté du 29 avril 2025](https://www.legifrance.gouv.fr/loda/id/JORFTEXT000051533180)
 - [Arrêté du 27 décembre 2023](https://www.legifrance.gouv.fr/loda/id/JORFTEXT000048708740)
+- [Arrêté du 26 décembre 2022](https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046821482)
 - [Arrêté du 24 décembre 2021](https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000044616004)
 - [Arrêté du 16 décembre 2020](https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000042731279)
 - [Arrêté du 27 décembre 2019](https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039684705)
@@ -16,3 +17,4 @@ Extraits de
 Licence ouverte.
 
 Maintenu par et pour [mon-entreprise](https://mon-entreprise.urssaf.fr/)
+

--- a/taux-2023.json
+++ b/taux-2023.json
@@ -1,0 +1,1292 @@
+[
+  {
+    "Nature du risque": "Fonderie de fonte, d'acier moulé ou de fonte malléable. Fabrication de fonte, d'acier, d'articles ou tubes en fonte. Fabrication de radiateurs, de chaudières pour le chauffage central, la cuisine.",
+    "Code risque": "27.1ZF",
+    "Taux net": "8,04%",
+    "Catégorie": "INDUSTRIES DE LA METALLURGIE"
+  },
+  {
+    "Nature du risque": "Métallurgie des métaux non ferreux et précieux. Laminage à chaud ou relaminage sans fabrication de fonte ni d'acier.",
+    "Code risque": "27.4CH",
+    "Taux net": "6,61%",
+    "Catégorie": "INDUSTRIES DE LA METALLURGIE"
+  },
+  {
+    "Nature du risque": "Fonderie des métaux légers ou non ferreux.",
+    "Code risque": "27.5EB",
+    "Taux net": "6,39%",
+    "Catégorie": "INDUSTRIES DE LA METALLURGIE"
+  },
+  {
+    "Nature du risque": "Construction métallique, fabrication de charpentes ; fournitures et armatures métalliques préparées pour le béton armé (préparation des armatures en ateliers hors chantiers). Travail à froid des métaux (étirage, laminage, profilage, pliage, tréfilage) et métallurgie des ferro-alliages.",
+    "Code risque": "28.1AD",
+    "Taux net": "5,09%",
+    "Catégorie": "INDUSTRIES DE LA METALLURGIE"
+  },
+  {
+    "Nature du risque": "Fabrication d'articles, de meubles et menuiseries, de fûts et emballages métalliques, de fils et câbles isolés. Fabrication de bouchage, d'emballage, de ferblanterie, de conditionnement métallique. Repoussage des métaux en feuilles. Fabrication d'accessoires d'ameublement en bronze et/ou fer forgé.",
+    "Code risque": "28.1CB",
+    "Taux net": "3,01%",
+    "Catégorie": "INDUSTRIES DE LA METALLURGIE"
+  },
+  {
+    "Nature du risque": "Chaudronnerie et soudure.",
+    "Code risque": "28.3CG",
+    "Taux net": "6,39%",
+    "Catégorie": "INDUSTRIES DE LA METALLURGIE"
+  },
+  {
+    "Nature du risque": "Fabrication de tubes en acier ou de tubes isolateurs (sauf tubes en fonte). Fabrication de chaudronnerie de contenants (réservoirs, citernes, bouteilles pour gaz comprimés), de générateurs de vapeur et accessoires, d'équipements généralement sous pression et de chaudronnerie nucléaire. Fabrication de tuyaux métalliques flexibles.",
+    "Code risque": "28.3CH",
+    "Taux net": "4,01%",
+    "Catégorie": "INDUSTRIES DE LA METALLURGIE"
+  },
+  {
+    "Nature du risque": "Forge, estampage, matriçage. Métallurgie des poudres et frittage.",
+    "Code risque": "28.4AD",
+    "Taux net": "3,88%",
+    "Catégorie": "INDUSTRIES DE LA METALLURGIE"
+  },
+  {
+    "Nature du risque": "Découpage, emboutissage. Sciage des métaux, graveurs-estampeurs. Décolletage.",
+    "Code risque": "28.4BI",
+    "Taux net": "3,12%",
+    "Catégorie": "INDUSTRIES DE LA METALLURGIE"
+  },
+  {
+    "Nature du risque": "Traitement et revêtement des métaux.",
+    "Code risque": "28.5AA",
+    "Taux net": "4,32%",
+    "Catégorie": "INDUSTRIES DE LA METALLURGIE"
+  },
+  {
+    "Nature du risque": "Mécanique industrielle.",
+    "Code risque": "28.5DA",
+    "Taux net": "3,88%",
+    "Catégorie": "INDUSTRIES DE LA METALLURGIE"
+  },
+  {
+    "Nature du risque": "Usinage de précision ou réparation d'articles métalliques divers.",
+    "Code risque": "28.5DF",
+    "Taux net": "2,10%",
+    "Catégorie": "INDUSTRIES DE LA METALLURGIE"
+  },
+  {
+    "Nature du risque": "Travaux d'intervention, de montage, démontage et entretien de matériels divers dans les usines. - Réparateurs mécaniciens. - Fabrication de manèges pour fêtes foraines.",
+    "Code risque": "28.5DG",
+    "Taux net": "4,98%",
+    "Catégorie": "INDUSTRIES DE LA METALLURGIE"
+  },
+  {
+    "Nature du risque": "Fabrication, montage, installation, entretien, réparation de machines, équipements, outillages : machine-outil, machine pour les industries de process, du textile, du cuir, de la chaussure ; matériel fixe et roulant pour le transport guidé ; matériel incendie ; ascenseur, monte-charge, porte automatique et escalier mécanique ; équipements de levage et de manutention.",
+    "Code risque": "28.6DF",
+    "Taux net": "2,27%",
+    "Catégorie": "INDUSTRIES DE LA METALLURGIE"
+  },
+  {
+    "Nature du risque": "Fabrication de boulonnerie, ressorts, visseries et quincaillerie. Fabrication et/ou entretien de couverts, couteaux, ciseaux, rasoirs. Fabrication d'articles de sport, jeux, jouets, articles de puériculture non classés par ailleurs.",
+    "Code risque": "28.6FB",
+    "Taux net": "2,26%",
+    "Catégorie": "INDUSTRIES DE LA METALLURGIE"
+  },
+  {
+    "Nature du risque": "Fabrication de composants mécaniques : transmissions hydrauliques et pneumatiques, turbines, compresseurs, roulements, matrices, poinçons, moules et modèles, organes mécaniques de transmission. Fabrication de moteurs autres que pour aéronefs, automobiles et motocycles. Reconstruction de moteurs sauf pour l'aéronautique.",
+    "Code risque": "29.1AF",
+    "Taux net": "2,30%",
+    "Catégorie": "INDUSTRIES DE LA METALLURGIE"
+  },
+  {
+    "Nature du risque": "Fabrication de pompes et d'articles de robinetterie.",
+    "Code risque": "29.1FB",
+    "Taux net": "2,23%",
+    "Catégorie": "INDUSTRIES DE LA METALLURGIE"
+  },
+  {
+    "Nature du risque": "Fabrication, installation, entretien, réparation de matériels aérauliques et thermiques, de fours et de brûleurs, d'appareils frigorifiques domestiques et industriels. Fabrication d'appareils ménagers électriques.",
+    "Code risque": "29.2FI",
+    "Taux net": "2,95%",
+    "Catégorie": "INDUSTRIES DE LA METALLURGIE"
+  },
+  {
+    "Nature du risque": "Fabrication et/ou réparation d'engins mobiles et systèmes pour : la construction, les mines, le forage, la préparation des minerais et matériaux, le matériel agricole.",
+    "Code risque": "29.3DC",
+    "Taux net": "3,01%",
+    "Catégorie": "INDUSTRIES DE LA METALLURGIE"
+  },
+  {
+    "Nature du risque": "Fabrication, réparation, entretien de : matériels électriques, électromagnétiques industriels, appareillages électriques d'installation, accumulateurs, isolateurs, piles, condensateurs, lampes électriques, matériels électriques pour moteurs et véhicules. Montage de petits matériels électriques. Réparation, entretien de matériels ménagers.",
+    "Code risque": "31.2AG",
+    "Taux net": "2,27%",
+    "Catégorie": "INDUSTRIES DE LA METALLURGIE"
+  },
+  {
+    "Nature du risque": "Fabrication, installation, entretien, réparation de : matériels et appareils électroniques de réception, de téléphonie, d'enregistrement, d'imagerie médicale, de composants, d'éléments chauffants. Fabrication, installation, entretien, réparation de matériel bureautique, informatique et activités connexes.",
+    "Code risque": "32.1BC",
+    "Taux net": "1,19%",
+    "Catégorie": "INDUSTRIES DE LA METALLURGIE"
+  },
+  {
+    "Nature du risque": "Fabrication, réparation de matériel médico-chirurgical, de prothèses y compris dentaires, d'instruments de précision, d'optique, d'horlogerie, de laboratoire. Emaillage, bijouterie, joaillerie, orfèvrerie, gravage de médailles, de monnaies (hors commerce).",
+    "Code risque": "33.1BC",
+    "Taux net": "1,69%",
+    "Catégorie": "INDUSTRIES DE LA METALLURGIE"
+  },
+  {
+    "Nature du risque": "Fabrication, installation d'appareils de mesure, de comptage, de signalisation, de contrôle, de sécurité, de régulation. Conception et installation de systèmes de contrôle et de production automatisée.",
+    "Code risque": "33.2BK",
+    "Taux net": "1,40%",
+    "Catégorie": "INDUSTRIES DE LA METALLURGIE"
+  },
+  {
+    "Nature du risque": "Construction de véhicules automobiles. Succursales et filiales des constructeurs.",
+    "Code risque": "34.1ZE",
+    "Taux net": "2,52%",
+    "Catégorie": "INDUSTRIES DE LA METALLURGIE"
+  },
+  {
+    "Nature du risque": "Construction de carrosseries, bennes, remorques autres que de tourisme. Fabrication de caravanes et véhicules de loisirs.",
+    "Code risque": "34.2AB",
+    "Taux net": "4,01%",
+    "Catégorie": "INDUSTRIES DE LA METALLURGIE"
+  },
+  {
+    "Nature du risque": "Fabrication d'équipements, de parties, d'accessoires et de pièces détachées pour l'automobile y compris équipements de carrosserie et de châssis.",
+    "Code risque": "34.3ZE",
+    "Taux net": "2,52%",
+    "Catégorie": "INDUSTRIES DE LA METALLURGIE"
+  },
+  {
+    "Nature du risque": "Construction, réparation ou peinture de navires en acier (y compris équipements spécifiques de bord).",
+    "Code risque": "35.1BF",
+    "Taux net": "8,04%",
+    "Catégorie": "INDUSTRIES DE LA METALLURGIE"
+  },
+  {
+    "Nature du risque": "Recherche, fabrication, entretien, maintenance, réparation, reconditionnement pour : aéronautique, aérospatiale, missiles, armement, structures, équipements.",
+    "Code risque": "35.3BC",
+    "Taux net": "1,10%",
+    "Catégorie": "INDUSTRIES DE LA METALLURGIE"
+  },
+  {
+    "Nature du risque": "Entreprises spécialisées dans l'installation de machines électriques dans les usines et établissements industriels.",
+    "Code risque": "45.3AA",
+    "Taux net": "3,16%",
+    "Catégorie": "INDUSTRIES DE LA METALLURGIE"
+  },
+  {
+    "Nature du risque": "Importation, commerce, entretien, réparation de véhicules automobiles de marque (importateurs, concessionnaires, agents, réparateurs agréés), commerce et réparation indépendante (à l'exception des 502ZH et 341ZE). Fabrication, réparation, commerce de motocycles, cycles et véhicules divers (y compris pièces et équipements). Electricité automobile.",
+    "Code risque": "50.1ZF",
+    "Taux net": "2,60%",
+    "Catégorie": "INDUSTRIES DE LA METALLURGIE"
+  },
+  {
+    "Nature du risque": "Dépannage, remorquage de véhicules automobiles (sans atelier de réparation et non annexé à un garage). Mécaniciens-réparateurs n'appartenant pas à un réseau de marque automobile. Fabrication ou fabrication associée à la réparation de menuiserie, tôlerie, sellerie, peintures spécialisées de voitures. Récupération de matières métalliques recyclables.",
+    "Code risque": "50.2ZH",
+    "Taux net": "3,81%",
+    "Catégorie": "INDUSTRIES DE LA METALLURGIE"
+  },
+  {
+    "Nature du risque": "Salariés occupant des fonctions supports de nature administrative dans des entreprises du BTP.",
+    "Code risque": "00.00A",
+    "Taux net": "0,71%",
+    "Catégorie": "INDUSTRIES DU BATIMENT ET DES TRAVAUX PUBLICS"
+  },
+  {
+    "Nature du risque": "Terrassements courants et travaux préparatoires spécialisés (y compris travaux paysagers sauf horticulture).",
+    "Code risque": "45.1AA",
+    "Taux net": "4,10%",
+    "Catégorie": "INDUSTRIES DU BATIMENT ET DES TRAVAUX PUBLICS"
+  },
+  {
+    "Nature du risque": "Autres travaux de gros œuvre. Entreprise générale du bâtiment. Construction métallique : montage, levage. Fumisterie industrielle.",
+    "Code risque": "45.2BE",
+    "Taux net": "7,66%",
+    "Catégorie": "INDUSTRIES DU BATIMENT ET DES TRAVAUX PUBLICS"
+  },
+  {
+    "Nature du risque": "Ouvrages d'art, autres travaux d'infrastructures spécialisés (forages et sondages, fondations spéciales, travaux souterrains, de voies ferrées, maritimes et fluviaux).",
+    "Code risque": "45.2CD",
+    "Taux net": "4,71%",
+    "Catégorie": "INDUSTRIES DU BATIMENT ET DES TRAVAUX PUBLICS"
+  },
+  {
+    "Nature du risque": "Construction et entretien de réseaux (électricité, eaux, gaz, télécommunications, etc…) et autres réseaux non classés par ailleurs.",
+    "Code risque": "45.2ED",
+    "Taux net": "4,84%",
+    "Catégorie": "INDUSTRIES DU BATIMENT ET DES TRAVAUX PUBLICS"
+  },
+  {
+    "Nature du risque": "Travaux de couverture, de charpente en bois, d'étanchéité.",
+    "Code risque": "45.2JD",
+    "Taux net": "9,17%",
+    "Catégorie": "INDUSTRIES DU BATIMENT ET DES TRAVAUX PUBLICS"
+  },
+  {
+    "Nature du risque": "Construction et entretien de chaussées (y compris sols sportifs et pavage). Fabrication de produits asphaltés ou enrobés (avec transport et mise en oeuvre).",
+    "Code risque": "45.2PB",
+    "Taux net": "4,19%",
+    "Catégorie": "INDUSTRIES DU BATIMENT ET DES TRAVAUX PUBLICS"
+  },
+  {
+    "Nature du risque": "Travaux de plomberie, de génie climatique, d'électricité, autres travaux d'installation technique non classés par ailleurs.",
+    "Code risque": "45.3AF",
+    "Taux net": "4,25%",
+    "Catégorie": "INDUSTRIES DU BATIMENT ET DES TRAVAUX PUBLICS"
+  },
+  {
+    "Nature du risque": "Travaux de menuiserie extérieure.",
+    "Code risque": "45.4CE",
+    "Taux net": "6,70%",
+    "Catégorie": "INDUSTRIES DU BATIMENT ET DES TRAVAUX PUBLICS"
+  },
+  {
+    "Nature du risque": "Travaux d'isolation, travaux de finitions (travaux d'aménagements intérieurs).",
+    "Code risque": "45.4LE",
+    "Taux net": "6,70%",
+    "Catégorie": "INDUSTRIES DU BATIMENT ET DES TRAVAUX PUBLICS"
+  },
+  {
+    "Nature du risque": "Entretien, réparation, location et montage de matériel pour le bâtiment et les travaux publics.",
+    "Code risque": "45.5ZB",
+    "Taux net": "5,09%",
+    "Catégorie": "INDUSTRIES DU BATIMENT ET DES TRAVAUX PUBLICS"
+  },
+  {
+    "Nature du risque": "Conception de projets architecturaux y compris décoration, ingénierie du BTP (y compris topographie, métrés, hygiène et sécurité, etc…).",
+    "Code risque": "74.2CE",
+    "Taux net": "0,87%",
+    "Catégorie": "INDUSTRIES DU BATIMENT ET DES TRAVAUX PUBLICS"
+  },
+  {
+    "Nature du risque": "Allocations complémentaires aux indemnités journalières de sécurité sociale versées soit par des organismes de prévoyance soit par des employeurs : activités de bâtiment (gros œuvre) et travaux publics.",
+    "Code risque": "75.3CA",
+    "Taux net": "6,13%",
+    "Catégorie": "INDUSTRIES DU BATIMENT ET DES TRAVAUX PUBLICS"
+  },
+  {
+    "Nature du risque": "Allocations complémentaires aux indemnités journalières de sécurité sociale versées soit par des organismes de prévoyance soit par des employeurs : autres activités.",
+    "Code risque": "75.3CB",
+    "Taux net": "4,04%",
+    "Catégorie": "INDUSTRIES DU BATIMENT ET DES TRAVAUX PUBLICS"
+  },
+  {
+    "Nature du risque": "Caisses de congés payés du bâtiment et des travaux publics (en ce qui concerne les indemnités versées par ces organismes).",
+    "Code risque": "91.1AA",
+    "Taux net": "0,55%",
+    "Catégorie": "INDUSTRIES DU BATIMENT ET DES TRAVAUX PUBLICS"
+  },
+  {
+    "Nature du risque": "Édition, imprimerie. Reprographie et activités connexes (reliure, dorure main, affiches, composition, photocomposition, gravure et photogravure). Routage.",
+    "Code risque": "22.2CD",
+    "Taux net": "1,91%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Traitement des déchets des activités industrielles, économiques et des ménages, récupération, tri, recyclage, valorisation matière y compris démantèlement, désamorçage, démolition de munitions.",
+    "Code risque": "37.1ZF",
+    "Taux net": "4,68%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Agents statutaires des industries électriques et gazières.",
+    "Code risque": "40.1ZE",
+    "Taux net": "0,17%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Salariés non statutaires des industries électriques et gazières.",
+    "Code risque": "40.1ZF",
+    "Taux net": "2,10%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Production et distribution de chauffage urbain, exploitants de chauffage d'immeubles, opérateurs d'efficacité énergétique, valorisation énergétique des déchets, usine d'incinération de résidus urbains.",
+    "Code risque": "40.3ZE",
+    "Taux net": "2,10%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Captage, traitement et distribution de l'eau.",
+    "Code risque": "41.0ZA",
+    "Taux net": "1,78%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Transport ferroviaire.",
+    "Code risque": "60.1ZA",
+    "Taux net": "1,50%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Transports terrestres de voyageurs, y compris par taxi.",
+    "Code risque": "60.2BD",
+    "Taux net": "3,74%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Téléphériques, remontées mécaniques.",
+    "Code risque": "60.2CA",
+    "Taux net": "3,74%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Transports routiers de marchandises. Location de véhicules avec chauffeur.",
+    "Code risque": "60.2MG",
+    "Taux net": "5,28%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Déménagement et garde-meubles.",
+    "Code risque": "60.2NA",
+    "Taux net": "5,97%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Transports aériens réguliers et non réguliers : personnel navigant et non navigant. Services aéroportuaires.",
+    "Code risque": "62.1ZC",
+    "Taux net": "1,91%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Ouvriers dockers maritimes intermittents, soumis au régime de la vignette, et effectuant quel que soit le classement de l'entreprise qui les emploie, des opérations de chargement, de déchargement ou de manutention de marchandises.",
+    "Code risque": "63.1AZ",
+    "Taux net": "35,00%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Manutention, chargement, déchargement, entreposage de marchandises ou fret dans les ports maritimes et fluviaux, et les aéroports.",
+    "Code risque": "63.1BE",
+    "Taux net": "8,31%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Entreposage et stockage non frigorifique non reliés à une voie d'eau. Entreposage de liquides en vrac.",
+    "Code risque": "63.1EE",
+    "Taux net": "3,32%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Transports par eau de marchandises et de passagers, et services auxiliaires.",
+    "Code risque": "63.2CF",
+    "Taux net": "2,77%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Agences de voyage. Offices de tourisme.",
+    "Code risque": "63.3ZC",
+    "Taux net": "0,92%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Entreprises de groupage effectuant directement ou non l'enlèvement ou la livraison à domicile des marchandises, messagerie, fret express.",
+    "Code risque": "63.4AA",
+    "Taux net": "3,91%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Affrètement et organisation des transports maritimes, routiers ou aériens. Gares routières et exploitation d'ouvrages routiers à péage.",
+    "Code risque": "63.4CI",
+    "Taux net": "1,61%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Services postaux et financiers.",
+    "Code risque": "64.1AA",
+    "Taux net": "2,59%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Autres activités de courrier : activités autres que celles exercées par La Poste. - Acheminement du courrier, lettre, colis généralement en express. - Activités de coursiers urbains et taxis-marchandises.",
+    "Code risque": "64.1CA",
+    "Taux net": "4,13%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Activités de télécommunications, y compris les activités de télésurveillance (sans personnel d'intervention sur le site surveillé).",
+    "Code risque": "64.2BB",
+    "Taux net": "0,84%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Créateurs et intermédiaires de publicité : régies publicitaires. Agences de presse y compris journalistes et photographes indépendants.",
+    "Code risque": "74.4BB",
+    "Taux net": "1,07%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Transports de fonds et services sécurisés.",
+    "Code risque": "74.6ZB",
+    "Taux net": "4,29%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Entreprises de travaux connexes aux sociétés de transports ferroviaires y compris la manutention dans les gares ferroviaires. Entreprises de nettoyage de matériel roulant sur les emprises de chemin de fer.",
+    "Code risque": "74.7ZE",
+    "Taux net": "3,74%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Acheminement et distribution de presse gratuite ou payante.",
+    "Code risque": "74.8GB",
+    "Taux net": "1,91%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Caisses de congés payés dans les ports et dans certaines entreprises de manutention et de transports (en ce qui concerne les indemnités versées par ces organismes).",
+    "Code risque": "75.3CC",
+    "Taux net": "0,55%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Ambulances.",
+    "Code risque": "85.1JA",
+    "Taux net": "4,34%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Services d'assainissement (sauf ceux visés sous le numéro 74.7ZF). Collecte et traitement des eaux usées.",
+    "Code risque": "90.0AA",
+    "Taux net": "3,45%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Collecte des déchets ménagers ou d'activités, dangereux ou non dangereux. Nettoiement de voirie-balayage, lavage.",
+    "Code risque": "90.0BF",
+    "Taux net": "4,45%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Caisses des congés payés des spectacles (en ce qui concerne les indemnités versées par ces organismes).",
+    "Code risque": "91.1AE",
+    "Taux net": "0,55%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Associations culturelles et socio-éducatives ne gérant pas d'équipements.",
+    "Code risque": "91.3EA",
+    "Taux net": "1,29%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Production de films et de programmes pour le cinéma, la télévision, la radiodiffusion, etc. … Enregistrement sonore et édition musicale. Distribution et projection de films. Activités photographiques (hors agences de presse). Gestion d'activités de spectacles et gestion d'activités culturelles et socio-éducatives.",
+    "Code risque": "92.1CC",
+    "Taux net": "1,02%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Création et interprétation littéraires et artistiques (y compris les artistes). Services annexes des spectacles (tout intermittent du spectacle).",
+    "Code risque": "92.3AD",
+    "Taux net": "1,93%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Gestion d'équipements et centres sportifs (personnel non visé par ailleurs et notamment aux risques 92.6CH et 92.6CI).",
+    "Code risque": "92.6AA",
+    "Taux net": "1,65%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Associations ou sociétés sportives ne gérant pas d'équipements.",
+    "Code risque": "92.6CG",
+    "Taux net": "1,35%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Sportifs professionnels, y compris entraîneurs joueurs, quel que soit le classement de l'établissement qui les emploie : rugby, escalade, moto, handball, basket, hockey, équitation, volley-ball, football, ski, cyclisme.",
+    "Code risque": "92.6CH",
+    "Taux net": "6,48%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Sportifs professionnels, pour les sports non visés par ailleurs, incluant également les entraîneurs non joueurs des sports visés par le 926CH, quel que soit le classement de l'établissement qui les emploie, arbitres et juges.",
+    "Code risque": "92.6CI",
+    "Taux net": "1,32%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Organisation de jeux de hasard et d'argent (dont courses de chevaux et de taureaux).",
+    "Code risque": "92.7AB",
+    "Taux net": "1,47%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Attractions foraines avec et sans montage de manèges ou de chapiteaux, et autres spectacles et services récréatifs.",
+    "Code risque": "92.7CC",
+    "Taux net": "2,20%",
+    "Catégorie": "INDUSTRIES DES TRANSPORTS, DE L'EAU, DU GAZ, DE L'ELECTRICITE, DU LIVRE ET DE LA COMMUNICATION"
+  },
+  {
+    "Nature du risque": "Cultures et élevage dans les départements d'outre-mer.",
+    "Code risque": "01.1AA",
+    "Taux net": "2,02%",
+    "Catégorie": "SERVICES, COMMERCES ET INDUSTRIES DE L'ALIMENTATION"
+  },
+  {
+    "Nature du risque": "Abattage du bétail, découpe et commerce de gros de viandes de boucherie. Production de viandes de volailles.",
+    "Code risque": "15.1AE",
+    "Taux net": "6,42%",
+    "Catégorie": "SERVICES, COMMERCES ET INDUSTRIES DE L'ALIMENTATION"
+  },
+  {
+    "Nature du risque": "Transformation et conservation de la viande et préparation de produits à base de viande (y compris boyauderie). Transformation et conservation du poisson.",
+    "Code risque": "15.1EC",
+    "Taux net": "5,00%",
+    "Catégorie": "SERVICES, COMMERCES ET INDUSTRIES DE L'ALIMENTATION"
+  },
+  {
+    "Nature du risque": "Autres industries alimentaires non classées par ailleurs et transformation du tabac.",
+    "Code risque": "15.5CC",
+    "Taux net": "2,58%",
+    "Catégorie": "SERVICES, COMMERCES ET INDUSTRIES DE L'ALIMENTATION"
+  },
+  {
+    "Nature du risque": "Transformation et conservation de légumes et de fruits. Fabrication industrielle de produits de boulangerie, pâtisserie et pizza.",
+    "Code risque": "15.8AC",
+    "Taux net": "3,71%",
+    "Catégorie": "SERVICES, COMMERCES ET INDUSTRIES DE L'ALIMENTATION"
+  },
+  {
+    "Nature du risque": "Commerce de détail (avec ou sans fabrication) de pain, pâtisserie, confiserie et chocolats.",
+    "Code risque": "15.8CD",
+    "Taux net": "2,19%",
+    "Catégorie": "SERVICES, COMMERCES ET INDUSTRIES DE L'ALIMENTATION"
+  },
+  {
+    "Nature du risque": "Fabrication et transformation de café et épices. Fabrication de boissons sauf produits laitiers.",
+    "Code risque": "15.9SC",
+    "Taux net": "1,84%",
+    "Catégorie": "SERVICES, COMMERCES ET INDUSTRIES DE L'ALIMENTATION"
+  },
+  {
+    "Nature du risque": "Intermédiaires de commerce en produits agricoles et alimentaires et vente par correspondance sans manutention, ni livraison, ni stockage, ni conditionnement.",
+    "Code risque": "51.1NB",
+    "Taux net": "0,81%",
+    "Catégorie": "SERVICES, COMMERCES ET INDUSTRIES DE L'ALIMENTATION"
+  },
+  {
+    "Nature du risque": "Commerce de gros (commerce interentreprises) alimentaire non spécialisé.",
+    "Code risque": "51.3TC",
+    "Taux net": "2,70%",
+    "Catégorie": "SERVICES, COMMERCES ET INDUSTRIES DE L'ALIMENTATION"
+  },
+  {
+    "Nature du risque": "Commerce de détail de produits laitiers, de produits surgelés, de fruits et légumes, de boissons et d'alimentation générale.",
+    "Code risque": "52.1BC",
+    "Taux net": "2,20%",
+    "Catégorie": "SERVICES, COMMERCES ET INDUSTRIES DE L'ALIMENTATION"
+  },
+  {
+    "Nature du risque": "Grande et moyenne distribution et Drive - Vente par automate.",
+    "Code risque": "52.1FB",
+    "Taux net": "3,56%",
+    "Catégorie": "SERVICES, COMMERCES ET INDUSTRIES DE L'ALIMENTATION"
+  },
+  {
+    "Nature du risque": "Commerce de détail de viandes, poissons, charcuterie artisanale y compris traiteurs, organisateurs de réception.",
+    "Code risque": "52.2CB",
+    "Taux net": "3,30%",
+    "Catégorie": "SERVICES, COMMERCES ET INDUSTRIES DE L'ALIMENTATION"
+  },
+  {
+    "Nature du risque": "Installations d'hébergement à équipements légers ou développés.",
+    "Code risque": "55.2EC",
+    "Taux net": "2,32%",
+    "Catégorie": "SERVICES, COMMERCES ET INDUSTRIES DE L'ALIMENTATION"
+  },
+  {
+    "Nature du risque": "Restaurants, café-tabac, hôtels avec ou sans restaurant et foyers.",
+    "Code risque": "55.3AC",
+    "Taux net": "2,27%",
+    "Catégorie": "SERVICES, COMMERCES ET INDUSTRIES DE L'ALIMENTATION"
+  },
+  {
+    "Nature du risque": "Restauration type rapide y compris wagons-lits et wagons-restaurants.",
+    "Code risque": "55.3BC",
+    "Taux net": "1,93%",
+    "Catégorie": "SERVICES, COMMERCES ET INDUSTRIES DE L'ALIMENTATION"
+  },
+  {
+    "Nature du risque": "Restauration collective.",
+    "Code risque": "55.5AA",
+    "Taux net": "4,19%",
+    "Catégorie": "SERVICES, COMMERCES ET INDUSTRIES DE L'ALIMENTATION"
+  },
+  {
+    "Nature du risque": "Entreposage frigorifique.",
+    "Code risque": "63.1DA",
+    "Taux net": "3,85%",
+    "Catégorie": "SERVICES, COMMERCES ET INDUSTRIES DE L'ALIMENTATION"
+  },
+  {
+    "Nature du risque": "Production, transport par conduite et raffinage de pétrole et de gaz. Fabrication d'ingrédients et additifs pour carburation et lubrification, de produits asphaltés et bitumeux. Commerce de gros des produits pétroliers. Fabrication de produits chimiques organiques de base. Fabrication de caoutchoucs synthétiques, d'élastomères, de matières plastiques.",
+    "Code risque": "11.1ZC",
+    "Taux net": "2,13%",
+    "Catégorie": "INDUSTRIES DE LA CHIMIE, DU CAOUTCHOUC ET DE LA PLASTURGIE"
+  },
+  {
+    "Nature du risque": "Production et transformation de matières nucléaires.",
+    "Code risque": "23.3ZA",
+    "Taux net": "1,49%",
+    "Catégorie": "INDUSTRIES DE LA CHIMIE, DU CAOUTCHOUC ET DE LA PLASTURGIE"
+  },
+  {
+    "Nature du risque": "Fabrication de produits chimiques minéraux et inorganiques, organiques de synthèse ou dérivés du bois, de produits azotés et d'engrais, d'abrasifs, de pigments, colorants, émaux, de produits photographiques, d'électrodes. Métallurgie de l'aluminium, des ferro-alliages et métaux légers. Electrométallurgie, électrochimie. Dénaturation d'éthanol.",
+    "Code risque": "24.1GN",
+    "Taux net": "4,08%",
+    "Catégorie": "INDUSTRIES DE LA CHIMIE, DU CAOUTCHOUC ET DE LA PLASTURGIE"
+  },
+  {
+    "Nature du risque": "Fabrication de peintures, vernis, colles, encres, mastics. Fabrication de gélatines et de leurs dérivés. Fabrication de produits d'entretien. Fabrication d'explosifs, d'articles de pyrotechnie, de poudres propulsives.",
+    "Code risque": "24.3ZC",
+    "Taux net": "2,39%",
+    "Catégorie": "INDUSTRIES DE LA CHIMIE, DU CAOUTCHOUC ET DE LA PLASTURGIE"
+  },
+  {
+    "Nature du risque": "Fabrication de préparations pharmaceutiques, de cosmétiques et de parfums. Fabrication et transformation d'extraits de végétaux, d'algues, bois résineux. Fabrication de produits de base pour détergents, de produits détergents, de pesticides et de biocides. Fabrication et traitement chimique de corps gras.",
+    "Code risque": "24.4CC",
+    "Taux net": "1,45%",
+    "Catégorie": "INDUSTRIES DE LA CHIMIE, DU CAOUTCHOUC ET DE LA PLASTURGIE"
+  },
+  {
+    "Nature du risque": "Fabrication d'articles en caoutchouc naturel ou synthétique à partir d'élastomères secs ou sous forme latex ou en solution.",
+    "Code risque": "25.1AC",
+    "Taux net": "3,06%",
+    "Catégorie": "INDUSTRIES DE LA CHIMIE, DU CAOUTCHOUC ET DE LA PLASTURGIE"
+  },
+  {
+    "Nature du risque": "Fabrication, assemblage d'articles et pièces en matières plastiques, y compris composites.",
+    "Code risque": "25.2HK",
+    "Taux net": "3,02%",
+    "Catégorie": "INDUSTRIES DE LA CHIMIE, DU CAOUTCHOUC ET DE LA PLASTURGIE"
+  },
+  {
+    "Nature du risque": "Chimie expert. Laboratoires de recherches chimiques.",
+    "Code risque": "73.1ZB",
+    "Taux net": "1,49%",
+    "Catégorie": "INDUSTRIES DE LA CHIMIE, DU CAOUTCHOUC ET DE LA PLASTURGIE"
+  },
+  {
+    "Nature du risque": "Extraction et préparation de matériaux issus des carrières de roches meubles ou massives.",
+    "Code risque": "14.1AH",
+    "Taux net": "4,28%",
+    "Catégorie": "INDUSTRIES DU BOIS, DE L'AMEUBLEMENT, DU PAPIER-CARTON, DU TEXTILE, DU VETEMENT, DES CUIRS ET DES PEAUX ET DES PIERRES ET TERRES A FEU"
+  },
+  {
+    "Nature du risque": "Extraction, broyage et préparation de produits minéraux divers.",
+    "Code risque": "14.5ZM",
+    "Taux net": "3,79%",
+    "Catégorie": "INDUSTRIES DU BOIS, DE L'AMEUBLEMENT, DU PAPIER-CARTON, DU TEXTILE, DU VETEMENT, DES CUIRS ET DES PEAUX ET DES PIERRES ET TERRES A FEU"
+  },
+  {
+    "Nature du risque": "Travail des fibres textiles naturelles (filature, moulinage et retordage, préparation de la laine, fibres dures, ouates…).",
+    "Code risque": "17.1KB",
+    "Taux net": "6,95%",
+    "Catégorie": "INDUSTRIES DU BOIS, DE L'AMEUBLEMENT, DU PAPIER-CARTON, DU TEXTILE, DU VETEMENT, DES CUIRS ET DES PEAUX ET DES PIERRES ET TERRES A FEU"
+  },
+  {
+    "Nature du risque": "Fabrication de tissu et articles textiles.",
+    "Code risque": "17.2AC",
+    "Taux net": "4,26%",
+    "Catégorie": "INDUSTRIES DU BOIS, DE L'AMEUBLEMENT, DU PAPIER-CARTON, DU TEXTILE, DU VETEMENT, DES CUIRS ET DES PEAUX ET DES PIERRES ET TERRES A FEU"
+  },
+  {
+    "Nature du risque": "Fabrication de mailles, dentelles, rubans, produits élastiques et d'articles divers.",
+    "Code risque": "17.7AB",
+    "Taux net": "2,46%",
+    "Catégorie": "INDUSTRIES DU BOIS, DE L'AMEUBLEMENT, DU PAPIER-CARTON, DU TEXTILE, DU VETEMENT, DES CUIRS ET DES PEAUX ET DES PIERRES ET TERRES A FEU"
+  },
+  {
+    "Nature du risque": "Confection. Fabrication d'accessoires de l'habillement et d'articles en toile.",
+    "Code risque": "18.2CB",
+    "Taux net": "2,47%",
+    "Catégorie": "INDUSTRIES DU BOIS, DE L'AMEUBLEMENT, DU PAPIER-CARTON, DU TEXTILE, DU VETEMENT, DES CUIRS ET DES PEAUX ET DES PIERRES ET TERRES A FEU"
+  },
+  {
+    "Nature du risque": "Maroquinerie.",
+    "Code risque": "19.2ZH",
+    "Taux net": "2,25%",
+    "Catégorie": "INDUSTRIES DU BOIS, DE L'AMEUBLEMENT, DU PAPIER-CARTON, DU TEXTILE, DU VETEMENT, DES CUIRS ET DES PEAUX ET DES PIERRES ET TERRES A FEU"
+  },
+  {
+    "Nature du risque": "Chaussure. Cuirs et peaux.",
+    "Code risque": "19.3ZL",
+    "Taux net": "4,73%",
+    "Catégorie": "INDUSTRIES DU BOIS, DE L'AMEUBLEMENT, DU PAPIER-CARTON, DU TEXTILE, DU VETEMENT, DES CUIRS ET DES PEAUX ET DES PIERRES ET TERRES A FEU"
+  },
+  {
+    "Nature du risque": "Scieries, y compris prestations de service, abattage et coupe de bois dans les DOM, fabrication de charbon de bois à usage domestique.",
+    "Code risque": "20.1AF",
+    "Taux net": "7,83%",
+    "Catégorie": "INDUSTRIES DU BOIS, DE L'AMEUBLEMENT, DU PAPIER-CARTON, DU TEXTILE, DU VETEMENT, DES CUIRS ET DES PEAUX ET DES PIERRES ET TERRES A FEU"
+  },
+  {
+    "Nature du risque": "Travail mécanique du bois, traitement et fabrication d'objets en bois.",
+    "Code risque": "20.1BB",
+    "Taux net": "4,51%",
+    "Catégorie": "INDUSTRIES DU BOIS, DE L'AMEUBLEMENT, DU PAPIER-CARTON, DU TEXTILE, DU VETEMENT, DES CUIRS ET DES PEAUX ET DES PIERRES ET TERRES A FEU"
+  },
+  {
+    "Nature du risque": "Menuiserie, charpentes et panneaux à base de bois et commerce menuiserie et panneaux.",
+    "Code risque": "20.3ZF",
+    "Taux net": "4,22%",
+    "Catégorie": "INDUSTRIES DU BOIS, DE L'AMEUBLEMENT, DU PAPIER-CARTON, DU TEXTILE, DU VETEMENT, DES CUIRS ET DES PEAUX ET DES PIERRES ET TERRES A FEU"
+  },
+  {
+    "Nature du risque": "Fabrication d'emballages issus du bois et d'articles de tonnellerie.",
+    "Code risque": "20.4ZI",
+    "Taux net": "6,02%",
+    "Catégorie": "INDUSTRIES DU BOIS, DE L'AMEUBLEMENT, DU PAPIER-CARTON, DU TEXTILE, DU VETEMENT, DES CUIRS ET DES PEAUX ET DES PIERRES ET TERRES A FEU"
+  },
+  {
+    "Nature du risque": "Production et transformation des pâtes à papier et carton.",
+    "Code risque": "21.2BD",
+    "Taux net": "3,33%",
+    "Catégorie": "INDUSTRIES DU BOIS, DE L'AMEUBLEMENT, DU PAPIER-CARTON, DU TEXTILE, DU VETEMENT, DES CUIRS ET DES PEAUX ET DES PIERRES ET TERRES A FEU"
+  },
+  {
+    "Nature du risque": "Fabrication, façonnage et travail technique du verre.",
+    "Code risque": "26.1EE",
+    "Taux net": "4,43%",
+    "Catégorie": "INDUSTRIES DU BOIS, DE L'AMEUBLEMENT, DU PAPIER-CARTON, DU TEXTILE, DU VETEMENT, DES CUIRS ET DES PEAUX ET DES PIERRES ET TERRES A FEU"
+  },
+  {
+    "Nature du risque": "Fabrication de vaisselle et d'objets en porcelaine ou en faïence.",
+    "Code risque": "26.2AG",
+    "Taux net": "4,18%",
+    "Catégorie": "INDUSTRIES DU BOIS, DE L'AMEUBLEMENT, DU PAPIER-CARTON, DU TEXTILE, DU VETEMENT, DES CUIRS ET DES PEAUX ET DES PIERRES ET TERRES A FEU"
+  },
+  {
+    "Nature du risque": "Fabrication de tuiles et briques et de produits céramiques non désignés par ailleurs.",
+    "Code risque": "26.2AH",
+    "Taux net": "4,89%",
+    "Catégorie": "INDUSTRIES DU BOIS, DE L'AMEUBLEMENT, DU PAPIER-CARTON, DU TEXTILE, DU VETEMENT, DES CUIRS ET DES PEAUX ET DES PIERRES ET TERRES A FEU"
+  },
+  {
+    "Nature du risque": "Fabrication d'appareils sanitaires en céramique.",
+    "Code risque": "26.2CA",
+    "Taux net": "13,53%",
+    "Catégorie": "INDUSTRIES DU BOIS, DE L'AMEUBLEMENT, DU PAPIER-CARTON, DU TEXTILE, DU VETEMENT, DES CUIRS ET DES PEAUX ET DES PIERRES ET TERRES A FEU"
+  },
+  {
+    "Nature du risque": "Fabrication de ciment, chaux, plâtre, produits en plâtre, agrégats légers, matériaux enrobés d'étanchéité et produits non désignés ailleurs.",
+    "Code risque": "26.5AB",
+    "Taux net": "1,77%",
+    "Catégorie": "INDUSTRIES DU BOIS, DE L'AMEUBLEMENT, DU PAPIER-CARTON, DU TEXTILE, DU VETEMENT, DES CUIRS ET DES PEAUX ET DES PIERRES ET TERRES A FEU"
+  },
+  {
+    "Nature du risque": "Fabrication de produits en béton.",
+    "Code risque": "26.6AA",
+    "Taux net": "4,84%",
+    "Catégorie": "INDUSTRIES DU BOIS, DE L'AMEUBLEMENT, DU PAPIER-CARTON, DU TEXTILE, DU VETEMENT, DES CUIRS ET DES PEAUX ET DES PIERRES ET TERRES A FEU"
+  },
+  {
+    "Nature du risque": "Préparation et livraison de béton prêt à l'emploi (sans mise en œuvre).",
+    "Code risque": "26.6EB",
+    "Taux net": "3,61%",
+    "Catégorie": "INDUSTRIES DU BOIS, DE L'AMEUBLEMENT, DU PAPIER-CARTON, DU TEXTILE, DU VETEMENT, DES CUIRS ET DES PEAUX ET DES PIERRES ET TERRES A FEU"
+  },
+  {
+    "Nature du risque": "Fabrication de produits en fibre-ciment.",
+    "Code risque": "26.6JB",
+    "Taux net": "99,00%",
+    "Catégorie": "INDUSTRIES DU BOIS, DE L'AMEUBLEMENT, DU PAPIER-CARTON, DU TEXTILE, DU VETEMENT, DES CUIRS ET DES PEAUX ET DES PIERRES ET TERRES A FEU"
+  },
+  {
+    "Nature du risque": "Fabrication et pose de produits de marbrerie.",
+    "Code risque": "26.7ZD",
+    "Taux net": "5,88%",
+    "Catégorie": "INDUSTRIES DU BOIS, DE L'AMEUBLEMENT, DU PAPIER-CARTON, DU TEXTILE, DU VETEMENT, DES CUIRS ET DES PEAUX ET DES PIERRES ET TERRES A FEU"
+  },
+  {
+    "Nature du risque": "Fabrication et réparation de navires en bois et en polyester stratifié.",
+    "Code risque": "35.1EB",
+    "Taux net": "4,34%",
+    "Catégorie": "INDUSTRIES DU BOIS, DE L'AMEUBLEMENT, DU PAPIER-CARTON, DU TEXTILE, DU VETEMENT, DES CUIRS ET DES PEAUX ET DES PIERRES ET TERRES A FEU"
+  },
+  {
+    "Nature du risque": "Fabrication et réparation de meubles et de cercueils en bois ou en matière similaire et d'instruments de musique.",
+    "Code risque": "36.1GC",
+    "Taux net": "4,35%",
+    "Catégorie": "INDUSTRIES DU BOIS, DE L'AMEUBLEMENT, DU PAPIER-CARTON, DU TEXTILE, DU VETEMENT, DES CUIRS ET DES PEAUX ET DES PIERRES ET TERRES A FEU"
+  },
+  {
+    "Nature du risque": "Fabrication et réparation de sièges, de matelas et sommiers et d'articles de literie et pour voiliers.",
+    "Code risque": "36.1MD",
+    "Taux net": "3,92%",
+    "Catégorie": "INDUSTRIES DU BOIS, DE L'AMEUBLEMENT, DU PAPIER-CARTON, DU TEXTILE, DU VETEMENT, DES CUIRS ET DES PEAUX ET DES PIERRES ET TERRES A FEU"
+  },
+  {
+    "Nature du risque": "Commerce du bois.",
+    "Code risque": "51.5EG",
+    "Taux net": "3,63%",
+    "Catégorie": "INDUSTRIES DU BOIS, DE L'AMEUBLEMENT, DU PAPIER-CARTON, DU TEXTILE, DU VETEMENT, DES CUIRS ET DES PEAUX ET DES PIERRES ET TERRES A FEU"
+  },
+  {
+    "Nature du risque": "Autres industries du cuir.",
+    "Code risque": "52.7AC",
+    "Taux net": "2,07%",
+    "Catégorie": "INDUSTRIES DU BOIS, DE L'AMEUBLEMENT, DU PAPIER-CARTON, DU TEXTILE, DU VETEMENT, DES CUIRS ET DES PEAUX ET DES PIERRES ET TERRES A FEU"
+  },
+  {
+    "Nature du risque": "Blanchisserie et teinturerie de gros, y compris la location de linge et vêtements professionnels blanchis.",
+    "Code risque": "71.4AC",
+    "Taux net": "4,59%",
+    "Catégorie": "INDUSTRIES DU BOIS, DE L'AMEUBLEMENT, DU PAPIER-CARTON, DU TEXTILE, DU VETEMENT, DES CUIRS ET DES PEAUX ET DES PIERRES ET TERRES A FEU"
+  },
+  {
+    "Nature du risque": "Blanchisserie et teinturerie de détail, y compris laverie automatique.",
+    "Code risque": "93.0BA",
+    "Taux net": "2,47%",
+    "Catégorie": "INDUSTRIES DU BOIS, DE L'AMEUBLEMENT, DU PAPIER-CARTON, DU TEXTILE, DU VETEMENT, DES CUIRS ET DES PEAUX ET DES PIERRES ET TERRES A FEU"
+  },
+  {
+    "Nature du risque": "Commerce et location de véhicules automobiles et d'équipements associés, de machines et équipements agricoles. Ecoles de conduite. Exploitation de parkings.",
+    "Code risque": "50.3AD",
+    "Taux net": "2,09%",
+    "Catégorie": "COMMERCES NON ALIMENTAIRES"
+  },
+  {
+    "Nature du risque": "Commerce de combustibles, charbons, carburants et lavages automatiques.",
+    "Code risque": "50.5ZB",
+    "Taux net": "2,94%",
+    "Catégorie": "COMMERCES NON ALIMENTAIRES"
+  },
+  {
+    "Nature du risque": "Commerce de gros sans manutention. Centrales d'achats et intermédiaires du commerce non alimentaire.",
+    "Code risque": "51.1RB",
+    "Taux net": "0,96%",
+    "Catégorie": "COMMERCES NON ALIMENTAIRES"
+  },
+  {
+    "Nature du risque": "Commerce de métaux, de biens d'occasion et commerce non alimentaire sur éventaires et marchés.",
+    "Code risque": "51.5CC",
+    "Taux net": "2,42%",
+    "Catégorie": "COMMERCES NON ALIMENTAIRES"
+  },
+  {
+    "Nature du risque": "Commerce de gros de matériaux de construction.",
+    "Code risque": "51.5FA",
+    "Taux net": "2,31%",
+    "Catégorie": "COMMERCES NON ALIMENTAIRES"
+  },
+  {
+    "Nature du risque": "Commerce de gros et location de matériel de bureau, électroménager, multimédia et informatique.",
+    "Code risque": "51.6GC",
+    "Taux net": "1,07%",
+    "Catégorie": "COMMERCES NON ALIMENTAIRES"
+  },
+  {
+    "Nature du risque": "Commerce de gros d'équipement industriel et de la maison, d'équipement de la personne et de produits pharmaceutiques.",
+    "Code risque": "51.6KC",
+    "Taux net": "1,41%",
+    "Catégorie": "COMMERCES NON ALIMENTAIRES"
+  },
+  {
+    "Nature du risque": "Intermédiaires du commerce avec manutention. Commerce de gros de produits chimiques et autres.",
+    "Code risque": "51.6LC",
+    "Taux net": "1,61%",
+    "Catégorie": "COMMERCES NON ALIMENTAIRES"
+  },
+  {
+    "Nature du risque": "Commerce de gros ou location de matériel de construction (bâtiment et travaux publics) et agricole.",
+    "Code risque": "51.6NC",
+    "Taux net": "2,46%",
+    "Catégorie": "COMMERCES NON ALIMENTAIRES"
+  },
+  {
+    "Nature du risque": "Commerce de détail de produits pharmaceutiques, d'articles médicaux et orthopédiques, d'optique et photographiques, de parfumerie et de produits de beauté.",
+    "Code risque": "52.3AC",
+    "Taux net": "1,03%",
+    "Catégorie": "COMMERCES NON ALIMENTAIRES"
+  },
+  {
+    "Nature du risque": "Commerce de détail de l'habillement, textiles, chaussures, maroquinerie. Vente à distance. Commerce de bijouterie, d'horlogerie, et d'orfèvrerie.",
+    "Code risque": "52.4CD",
+    "Taux net": "1,54%",
+    "Catégorie": "COMMERCES NON ALIMENTAIRES"
+  },
+  {
+    "Nature du risque": "Grands magasins, magasins multi-commerces ou magasins populaires, commerces de meubles et de décoration de la maison.",
+    "Code risque": "52.4HC",
+    "Taux net": "2,37%",
+    "Catégorie": "COMMERCES NON ALIMENTAIRES"
+  },
+  {
+    "Nature du risque": "Commerce de détail et location de matériel électroménager, multimédia, informatique.",
+    "Code risque": "52.4LA",
+    "Taux net": "1,57%",
+    "Catégorie": "COMMERCES NON ALIMENTAIRES"
+  },
+  {
+    "Nature du risque": "Commerce de détail de bricolage (surface de vente supérieure ou égale à 400 m2).",
+    "Code risque": "52.4PB",
+    "Taux net": "2,74%",
+    "Catégorie": "COMMERCES NON ALIMENTAIRES"
+  },
+  {
+    "Nature du risque": "Commerce de détail et location associée d'articles de sport et de loisirs, y compris cycles.",
+    "Code risque": "52.4WA",
+    "Taux net": "1,36%",
+    "Catégorie": "COMMERCES NON ALIMENTAIRES"
+  },
+  {
+    "Nature du risque": "Commerce de fleurs et d'animaux d'agrément.",
+    "Code risque": "52.4XB",
+    "Taux net": "1,98%",
+    "Catégorie": "COMMERCES NON ALIMENTAIRES"
+  },
+  {
+    "Nature du risque": "Commerce de détail de quincaillerie et de droguerie (surface de vente inférieure à 400 m2), céramique mobilière, arts de la table, jouets, instruments de musique, et autres.",
+    "Code risque": "52.4ZD",
+    "Taux net": "1,79%",
+    "Catégorie": "COMMERCES NON ALIMENTAIRES"
+  },
+  {
+    "Nature du risque": "Promotion, vente, location ou administration de biens immobiliers.",
+    "Code risque": "70.3AD",
+    "Taux net": "1,27%",
+    "Catégorie": "COMMERCES NON ALIMENTAIRES"
+  },
+  {
+    "Nature du risque": "Concierges et employés d'immeubles.",
+    "Code risque": "70.3CB",
+    "Taux net": "3,12%",
+    "Catégorie": "COMMERCES NON ALIMENTAIRES"
+  },
+  {
+    "Nature du risque": "Location de biens de consommation (mobiliers, linges, bâches, sacs, etc.) et d'autres biens d'équipements.",
+    "Code risque": "71.4AB",
+    "Taux net": "1,91%",
+    "Catégorie": "COMMERCES NON ALIMENTAIRES"
+  },
+  {
+    "Nature du risque": "Organismes et auxiliaires financiers - Bourse de commerce.",
+    "Code risque": "65.1AB",
+    "Taux net": "0,75%",
+    "Catégorie": "ACTIVITES DE SERVICES I"
+  },
+  {
+    "Nature du risque": "Assurances et auxiliaires d'assurances.",
+    "Code risque": "66.0AB",
+    "Taux net": "0,83%",
+    "Catégorie": "ACTIVITES DE SERVICES I"
+  },
+  {
+    "Nature du risque": "Travaux informatiques à façon.",
+    "Code risque": "72.3ZA",
+    "Taux net": "0,86%",
+    "Catégorie": "ACTIVITES DE SERVICES I"
+  },
+  {
+    "Nature du risque": "Etablissements de recherche scientifique et technique.",
+    "Code risque": "73.1ZE",
+    "Taux net": "0,95%",
+    "Catégorie": "ACTIVITES DE SERVICES I"
+  },
+  {
+    "Nature du risque": "Groupements d'employeurs. Coopératives d'activité et d'emploi. Services divers rendus principalement aux entreprises non désignés par ailleurs.",
+    "Code risque": "74.1GB",
+    "Taux net": "0,75%",
+    "Catégorie": "ACTIVITES DE SERVICES I"
+  },
+  {
+    "Nature du risque": "Crédit-bail mobilier et immobilier, location de brevets. Cabinets juridiques et offices publics ou ministériels. Cabinets d'expertise comptable et d'analyse financière. Cabinets d'études informatiques et d'organisation.",
+    "Code risque": "74.1GD",
+    "Taux net": "0,75%",
+    "Catégorie": "ACTIVITES DE SERVICES I"
+  },
+  {
+    "Nature du risque": "Holdings. Cabinets de conseils en information et documentation. Cabinets d'études économiques, sociologiques, marchandisage.",
+    "Code risque": "74.1JB",
+    "Taux net": "0,75%",
+    "Catégorie": "ACTIVITES DE SERVICES I"
+  },
+  {
+    "Nature du risque": "Cabinets d'études techniques : agences de brevets, expertises, expertises en œuvre d'art. - Expert chargé d'évaluer les dommages (ou les risques).",
+    "Code risque": "74.2CB",
+    "Taux net": "0,86%",
+    "Catégorie": "ACTIVITES DE SERVICES I"
+  },
+  {
+    "Nature du risque": "Bureaux d'essais, bancs d'essais.",
+    "Code risque": "74.3BA",
+    "Taux net": "1,30%",
+    "Catégorie": "ACTIVITES DE SERVICES I"
+  },
+  {
+    "Nature du risque": "Administration centrale et services extérieurs des administrations (y compris leurs établissements publics). Représentation diplomatique étrangère en France. Organismes internationaux. - Service des armées alliées.",
+    "Code risque": "75.1AG",
+    "Taux net": "1,02%",
+    "Catégorie": "ACTIVITES DE SERVICES I"
+  },
+  {
+    "Nature du risque": "Collectivités territoriales (communales, départementales, régionales…) y compris leurs établissements publics hors secteur médico-social.",
+    "Code risque": "75.1BA",
+    "Taux net": "1,81%",
+    "Catégorie": "ACTIVITES DE SERVICES I"
+  },
+  {
+    "Nature du risque": "Personnes détenues, quelle que soit l'activité exercée.",
+    "Code risque": "75.2EE",
+    "Taux net": "1,27%",
+    "Catégorie": "ACTIVITES DE SERVICES I"
+  },
+  {
+    "Nature du risque": "Activités générales de sécurité sociale.",
+    "Code risque": "75.3AA",
+    "Taux net": "1,02%",
+    "Catégorie": "ACTIVITES DE SERVICES I"
+  },
+  {
+    "Nature du risque": "Couverture du risque chômage et autres garanties du maintien de revenu, y compris la caisse nationale de surcompensation du bâtiment et des travaux publics et caisses de retraite ne relevant pas de la législation sur les assurances.",
+    "Code risque": "75.3BB",
+    "Taux net": "0,83%",
+    "Catégorie": "ACTIVITES DE SERVICES I"
+  },
+  {
+    "Nature du risque": "Personnel enseignant et administratif des établissements d'enseignement privés et des organismes de formation.",
+    "Code risque": "80.1ZA",
+    "Taux net": "1,23%",
+    "Catégorie": "ACTIVITES DE SERVICES I"
+  },
+  {
+    "Nature du risque": "Elèves et étudiants des établissements publics ou privés d'enseignement secondaire, supérieur ou spécialisé visés à l'article L. 412-8 (2°, b) du code de la sécurité sociale.",
+    "Code risque": "80.2AA",
+    "Taux net": "0,0015%",
+    "Catégorie": "ACTIVITES DE SERVICES I"
+  },
+  {
+    "Nature du risque": "Elèves et étudiants des établissements publics et privés d'enseignement technique visés à l'article L. 412-8 (2°, a) du code de la sécurité sociale.",
+    "Code risque": "80.2CA",
+    "Taux net": "0,0171%",
+    "Catégorie": "ACTIVITES DE SERVICES I"
+  },
+  {
+    "Nature du risque": "Activités des organisations consulaires et patronales, des organisations professionnelles, des syndicats de salariés, des organisations religieuses, des organisations politiques et des organisations associatives non classées ailleurs.",
+    "Code risque": "91.3EJ",
+    "Taux net": "1,24%",
+    "Catégorie": "ACTIVITES DE SERVICES I"
+  },
+  {
+    "Nature du risque": "Personnel permanent des entreprises de travail temporaire.",
+    "Code risque": "74.5BC",
+    "Taux net": "0,90%",
+    "Catégorie": "ACTIVITES DE SERVICES II"
+  },
+  {
+    "Nature du risque": "Toutes catégories de personnel de travail temporaire.",
+    "Code risque": "74.5BD",
+    "Taux net": "3,20%",
+    "Catégorie": "ACTIVITES DE SERVICES II"
+  },
+  {
+    "Nature du risque": "Travail temporaire : personnel de bureau et personnel paramédical.",
+    "Code risque": "74.5BE",
+    "Taux net": "0,90%",
+    "Catégorie": "ACTIVITES DE SERVICES II"
+  },
+  {
+    "Nature du risque": "Agences privées de recherches, entreprises de surveillance (sans transports de fonds).",
+    "Code risque": "74.6ZA",
+    "Taux net": "2,56%",
+    "Catégorie": "ACTIVITES DE SERVICES II"
+  },
+  {
+    "Nature du risque": "Services de nettoyage de locaux et d'objets divers. Activités de désinfection, de désinsectisation et de dératisation.",
+    "Code risque": "74.7ZF",
+    "Taux net": "3,98%",
+    "Catégorie": "ACTIVITES DE SERVICES II"
+  },
+  {
+    "Nature du risque": "Entreprises de conditionnement non spécialisées.",
+    "Code risque": "74.8DA",
+    "Taux net": "3,73%",
+    "Catégorie": "ACTIVITES DE SERVICES II"
+  },
+  {
+    "Nature du risque": "Travaux à façon divers sauf la location de brevets, entreposage d'archives d'entreprises (y compris la consultation d'archives). Ionisation de produits divers.",
+    "Code risque": "74.8KC",
+    "Taux net": "1,24%",
+    "Catégorie": "ACTIVITES DE SERVICES II"
+  },
+  {
+    "Nature du risque": "Etablissements publics médico-sociaux des collectivités territoriales.",
+    "Code risque": "75.1CC",
+    "Taux net": "1,36%",
+    "Catégorie": "ACTIVITES DE SERVICES II"
+  },
+  {
+    "Nature du risque": "Accueil à domicile à titre onéreux, d'enfants, de personnes âgées ou d'adultes handicapés confiés par des organismes publics, des œuvres, des établissements ou des services de soins.",
+    "Code risque": "75.1CD",
+    "Taux net": "1,60%",
+    "Catégorie": "ACTIVITES DE SERVICES II"
+  },
+  {
+    "Nature du risque": "Administration hospitalière, y compris ses établissements publics.",
+    "Code risque": "75.1CE",
+    "Taux net": "1,36%",
+    "Catégorie": "ACTIVITES DE SERVICES II"
+  },
+  {
+    "Nature du risque": "Services de soins privés médicaux exclusivement à domicile.",
+    "Code risque": "85.1AC",
+    "Taux net": "2,38%",
+    "Catégorie": "ACTIVITES DE SERVICES II"
+  },
+  {
+    "Nature du risque": "Etablissements de soins privés y compris les centres de réadaptation fonctionnelle, autres instituts pour la santé (établissements thermaux, etc.).",
+    "Code risque": "85.1AD",
+    "Taux net": "2,38%",
+    "Catégorie": "ACTIVITES DE SERVICES II"
+  },
+  {
+    "Nature du risque": "Médecine systématique et de dépistage (y compris les centres interentreprises de médecine du travail).",
+    "Code risque": "85.1CB",
+    "Taux net": "0,87%",
+    "Catégorie": "ACTIVITES DE SERVICES II"
+  },
+  {
+    "Nature du risque": "Cabinets de soins : médicaux et dentaires.",
+    "Code risque": "85.1CD",
+    "Taux net": "1,17%",
+    "Catégorie": "ACTIVITES DE SERVICES II"
+  },
+  {
+    "Nature du risque": "Cabinets d'auxiliaires médicaux.",
+    "Code risque": "85.1GA",
+    "Taux net": "2,38%",
+    "Catégorie": "ACTIVITES DE SERVICES II"
+  },
+  {
+    "Nature du risque": "Laboratoires d'analyses médicales extrahospitaliers.",
+    "Code risque": "85.1KA",
+    "Taux net": "1,17%",
+    "Catégorie": "ACTIVITES DE SERVICES II"
+  },
+  {
+    "Nature du risque": "Centres de transfusion sanguine et banques d'organes. Vétérinaires. Cliniques vétérinaires.",
+    "Code risque": "85.2ZB",
+    "Taux net": "2,38%",
+    "Catégorie": "ACTIVITES DE SERVICES II"
+  },
+  {
+    "Nature du risque": "Services d'aide sociale à domicile (auxiliaires de vie, aides ménagères…).",
+    "Code risque": "85.3AB",
+    "Taux net": "3,78%",
+    "Catégorie": "ACTIVITES DE SERVICES II"
+  },
+  {
+    "Nature du risque": "Accueil, hébergement en établissement pour personnes âgées (maisons de retraite…).",
+    "Code risque": "85.3AC",
+    "Taux net": "3,78%",
+    "Catégorie": "ACTIVITES DE SERVICES II"
+  },
+  {
+    "Nature du risque": "Accueil, hébergement en établissement pour personnes handicapées (enfants et adultes).",
+    "Code risque": "85.3AD",
+    "Taux net": "3,78%",
+    "Catégorie": "ACTIVITES DE SERVICES II"
+  },
+  {
+    "Nature du risque": "Accueil, hébergement, prévention pour petite enfance, l'enfance, l'adolescence.",
+    "Code risque": "85.3AE",
+    "Taux net": "3,78%",
+    "Catégorie": "ACTIVITES DE SERVICES II"
+  },
+  {
+    "Nature du risque": "Action sociale sous toutes ses formes hors risques 853AB/853AC/853AD/853AE.",
+    "Code risque": "85.3BA",
+    "Taux net": "3,78%",
+    "Catégorie": "ACTIVITES DE SERVICES II"
+  },
+  {
+    "Nature du risque": "Stagiaires des centres de formation professionnelle, de réadaptation fonctionnelle, de rééducation professionnelle.",
+    "Code risque": "85.3HA",
+    "Taux net": "2,24%",
+    "Catégorie": "ACTIVITES DE SERVICES II"
+  },
+  {
+    "Nature du risque": "Travailleurs handicapés des établissements ou services d'aide par le travail.",
+    "Code risque": "85.3HB",
+    "Taux net": "1,92%",
+    "Catégorie": "ACTIVITES DE SERVICES II"
+  },
+  {
+    "Nature du risque": "Association intermédiaire (personnes dépourvues d'emploi et mises à disposition).",
+    "Code risque": "85.3KL",
+    "Taux net": "3,36%",
+    "Catégorie": "ACTIVITES DE SERVICES II"
+  },
+  {
+    "Nature du risque": "Coiffure. Fabrication de postiches. Esthétique corporelle.",
+    "Code risque": "93.0DB",
+    "Taux net": "2,07%",
+    "Catégorie": "ACTIVITES DE SERVICES II"
+  },
+  {
+    "Nature du risque": "Pompes funèbres et services annexes, y compris le commerce d'articles funéraires.",
+    "Code risque": "93.0HB",
+    "Taux net": "3,41%",
+    "Catégorie": "ACTIVITES DE SERVICES II"
+  },
+  {
+    "Nature du risque": "Services personnels divers (y compris cabinets de graphologie, agences matrimoniales).",
+    "Code risque": "93.0NC",
+    "Taux net": "4,14%",
+    "Catégorie": "ACTIVITES DE SERVICES II"
+  },
+  {
+    "Nature du risque": "Voyageurs de commerce, représentants, placier non exclusif (au service de plusieurs employeurs).",
+    "Code risque": "51.1TG",
+    "Taux net": "1,10%",
+    "Catégorie": "CATEGORIES DE TRAVAILLEURS VISES L'ARTICLE D 242-6-22 DU CODE DE LA SECURITE SOCIALE"
+  },
+  {
+    "Nature du risque": "Salariés d'un employeur ne comportant pas d'établissement en France, visé à l'article L 243-1-2 du code de la sécurité sociale.",
+    "Code risque": "51.1TH",
+    "Taux net": "1,04%",
+    "Catégorie": "CATEGORIES DE TRAVAILLEURS VISES L'ARTICLE D 242-6-22 DU CODE DE LA SECURITE SOCIALE"
+  },
+  {
+    "Nature du risque": "Vendeurs colporteurs de presse, porteurs de presse visés à l'article L. 311-3 (18°) du code de la sécurité sociale.",
+    "Code risque": "52.4RB",
+    "Taux net": "1,90%",
+    "Catégorie": "CATEGORIES DE TRAVAILLEURS VISES L'ARTICLE D 242-6-22 DU CODE DE LA SECURITE SOCIALE"
+  },
+  {
+    "Nature du risque": "Vendeurs à domicile visés à l'article L. 311-3 (20°) du code de la sécurité sociale.",
+    "Code risque": "52.6GA",
+    "Taux net": "1,55%",
+    "Catégorie": "CATEGORIES DE TRAVAILLEURS VISES L'ARTICLE D 242-6-22 DU CODE DE LA SECURITE SOCIALE"
+  },
+  {
+    "Nature du risque": "Accueil à domicile, à titre onéreux, d'enfants pour le compte de particuliers et de personnes âgées ou d'adultes handicapés sur leur propre demande ou pour le compte de particuliers.",
+    "Code risque": "85.3CA",
+    "Taux net": "0,81%",
+    "Catégorie": "CATEGORIES DE TRAVAILLEURS VISES L'ARTICLE D 242-6-22 DU CODE DE LA SECURITE SOCIALE"
+  },
+  {
+    "Nature du risque": "Toute personne occupée exclusivement au service de particuliers : employés de maison (femme de ménage, lingère, couturière, blanchisseuse à la journée, chauffeur de maître).",
+    "Code risque": "95.0ZA",
+    "Taux net": "2,21%",
+    "Catégorie": "CATEGORIES DE TRAVAILLEURS VISES L'ARTICLE D 242-6-22 DU CODE DE LA SECURITE SOCIALE"
+  },
+  {
+    "Nature du risque": "Toute personne effectuant des travaux de courte durée pour le compte de particuliers : travaux de bureaux ou assimilables.",
+    "Code risque": "95.0ZC",
+    "Taux net": "0,80%",
+    "Catégorie": "CATEGORIES DE TRAVAILLEURS VISES L'ARTICLE D 242-6-22 DU CODE DE LA SECURITE SOCIALE"
+  },
+  {
+    "Nature du risque": "Toute personne effectuant des travaux de courte durée pour le compte de particuliers : travaux industriels (relevant généralement de professions du bâtiment).",
+    "Code risque": "95.0ZD",
+    "Taux net": "7,66%",
+    "Catégorie": "CATEGORIES DE TRAVAILLEURS VISES L'ARTICLE D 242-6-22 DU CODE DE LA SECURITE SOCIALE"
+  },
+  {
+    "Nature du risque": "Salariés occupant des fonctions supports de nature administrative dans des entreprises relevant de branches professionnelles autres que celle du BTP.",
+    "Code risque": "00.00B",
+    "Taux net": "0,80%",
+    "Catégorie": "CATEGORIES DE PERSONNELS VISES A L'ARTICLE 1er (III) DE L'ARRETE DU 17 OCTOBRE 1995 RELATIF A LA TARIFICATION DES RISQUES D'ACCIDENTS DU TRAVAIL ET DE MALADIES PROFESSIONNELLES"
+  }
+]


### PR DESCRIPTION
Ajout de tous les taux 2023, tirés de [l'arrêté du 26 décembre 2022](https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046821482). Le format est le même que les autres années.